### PR TITLE
Adding Goodwe Solar power stats to default repositories

### DIFF
--- a/custom_components/hacs/const.py
+++ b/custom_components/hacs/const.py
@@ -87,5 +87,6 @@ DEFAULT_REPOSITORIES = {
         "thomasloven/lovelace-markdown-mod",
         "thomasloven/lovelace-slider-entity-row",
         "isabellaalstrom/krisinfo-card",
+        "timsoethout/goodwe-sems-home-assistant",
     ],
 }


### PR DESCRIPTION
Hi, One of the users of a component I put on Github [asked me](https://github.com/TimSoethout/goodwe-sems-home-assistant/pull/6) to add this component to HACS. 
I hope this change is correct.