### PR TITLE
Add the sems2mqtt repostory

### DIFF
--- a/custom_components/hacs/const.py
+++ b/custom_components/hacs/const.py
@@ -81,6 +81,7 @@ DEFAULT_REPOSITORIES = {
         "timsoethout/goodwe-sems-home-assistant",
         "bramkragten/lyric",
         "bramkragten/mind",
+        "bouwew/sems2mqtt",
     ],
     "plugin": [
         "maykar/compact-custom-header",


### PR DESCRIPTION
I've built a variant of the GoodWe SEMS custom component,

This one requires an MQTT broker to be present.
Also, it make use of the HA MQTT discovery to integrate the sensors directly into HA, so no extra sensors to set up.