### PR TITLE
Add apop880 AD apps to default repositories

### DIFF
--- a/custom_components/hacs/const.py
+++ b/custom_components/hacs/const.py
@@ -73,7 +73,11 @@ ERROR = [
 ################################
 
 DEFAULT_REPOSITORIES = {
-    "appdaemon": [],
+    "appdaemon": [
+        "apop880/SmartThings-Button",
+        "apop880/White-Noise",
+        "apop880/Night-Mode"
+    ],
     "integration": [
         "StyraHem/ShellyForHASS",
         "isabellaalstrom/sensor.krisinformation",


### PR DESCRIPTION
Adding three basic AppDaemon apps to help launch the new functionality.