### PR TITLE
Adding Meross IoT library

### DIFF
--- a/custom_components/hacs/const.py
+++ b/custom_components/hacs/const.py
@@ -91,6 +91,7 @@ DEFAULT_REPOSITORIES = {
         "bouwew/sems2mqtt",
         "akasma74/Hass-Custom-Alarm",
         "keatontaylor/alexa_media_player",
+        "albertogeniola/meross-homeassistant"
     ],
     "plugin": [
         "maykar/compact-custom-header",


### PR DESCRIPTION
Proposing the Meross HomeAssistant Custom component as default one.