### PR TITLE
Don't use pre-release

### DIFF
--- a/docs/installation/terminal.md
+++ b/docs/installation/terminal.md
@@ -11,7 +11,7 @@ Then run the following commands:
 ```bash
 git clone https://github.com/custom-components/hacs.git hacs_temp
 cd hacs_temp
-git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+git checkout $(git describe --tags --always $(git rev-list --tags --max-count=1000) | grep -e "[0-9]\+\.[0-9]\+\.[0-9]\+$" | head -n 1)
 cd ../
 cp -r hacs_temp/custom_components/hacs hacs
 rm -R hacs_temp


### PR DESCRIPTION
`git describe --tags --always $(git rev-list --tags --max-count=1000) | grep -e "[0-9]\+\.[0-9]\+\.[0-9]\+$"`
returns 
```
0.9.0
0.8.1
0.8.0
0.7.0
0.6.0
0.5.1
0.5.0
0.4.4
0.4.3
0.4.2
0.4.1
0.4.0
0.2.1
0.2.0
0.1.0
```