### PR TITLE
Add 3 Phillips TV Ambilight Integrations

### DIFF
--- a/repositories/integration
+++ b/repositories/integration
@@ -17,8 +17,8 @@
   "Ceerbeerus/beerbolaget",
   "thomasloven/hass-browser_mod",
   "claytonjn/hass-circadian_lighting",
-  "xMrVizzy/Philips-AirPurifier"
+  "xMrVizzy/Philips-AirPurifier",
   "jomwells/ambilights",
   "jomwells/ambihue",
-  "jomwells/ambilight-yeelight",
+  "jomwells/ambilight-yeelight"
 ]

--- a/repositories/integration
+++ b/repositories/integration
@@ -18,4 +18,7 @@
   "thomasloven/hass-browser_mod",
   "claytonjn/hass-circadian_lighting",
   "xMrVizzy/Philips-AirPurifier"
+  "jomwells/ambilights",
+  "jomwells/ambihue",
+  "jomwells/ambilight-yeelight",
 ]


### PR DESCRIPTION
Three custom components for controlling the Ambilight LED's of Phillips TV's (all three tie in well with nstrelow/ha_philips_android_tv)
- The Philips TV [Ambilight (Light) Component](https://github.com/jomwells/ambilights) (philips_ambilight)
- The [Ambilight+Hue ON/OFF (Switch)](https://github.com/jomwells/ambihue) Component (philips_ambilight+hue)
- The [Ambilight+Yeelight (Switch)](https://github.com/jomwells/ambilight-yeelight) Component (philips_ambilight+yeelight)