### PR TITLE
Fixed typo in error message

### DIFF
--- a/custom_components/hacs/frontend/views/api.py
+++ b/custom_components/hacs/frontend/views/api.py
@@ -174,7 +174,7 @@ class HacsAPIView(HacsViewBase):
                         repository_name
                     )
                     if is_known_repository:
-                        message = "{} is allready registered, look for it in the store.".format(
+                        message = "{} is already registered, look for it in the store.".format(
                             repository_name
                         )
                         raise web.HTTPFound(


### PR DESCRIPTION
There is a typographical error in the error message in `custom_components/hacs/frontend/views/api.py` on line 177 which reads:

```python
message = "{} is allready registered, look for it in the store.".format(
```

it should read:

```python
message = "{} is already registered, look for it in the store.".format(
```