### PR TITLE
Updated a wrong link in the general.md

### DIFF
--- a/docs/developer/general.md
+++ b/docs/developer/general.md
@@ -2,7 +2,7 @@
 
 For your repository to be added there are a few criteria that need to be met.
 
-- See [Integration developer](../intgegration) for integrations.
+- See [Integration developer](../integration) for integrations.
 - See [Plugin developer](../plugin) for plugins.
 
 ## Repository information


### PR DESCRIPTION
I have fixed a wrong link at the start of the document ("Integration Developer")