### PR TITLE
Add homeassistant-elasticsearch integration

### DIFF
--- a/repositories/integration
+++ b/repositories/integration
@@ -24,5 +24,6 @@
   "Paul-dH/Home-Assisant-Sensor-OvApi",
   "rt400/School-Vacation",
   "xirixiz/Home-Assistant-Sensor-Afvalwijzer",
-  "bieniu/ha-airly"
+  "bieniu/ha-airly",
+  "legrego/homeassistant-elasticsearch"
 ]


### PR DESCRIPTION
Adds the `homeassistant-elasticsearch` integration to the default HACS store.