### PR TITLE
Add two custom components to manage Sinopé tech devices

### DIFF
--- a/repositories/integration
+++ b/repositories/integration
@@ -27,5 +27,7 @@
   "bieniu/ha-airly",
   "legrego/homeassistant-elasticsearch",
   "kalanda/homeassistant-aemet-sensor",
-  "basschipper/homeassistant-generic-hygrostat"
+  "basschipper/homeassistant-generic-hygrostat",
+  "claudegel/sinope-1",
+  "claudegel/sinope-gt125"
 ]


### PR DESCRIPTION
Adding sinope-1 to manage devices via neviweb portal from Sinopé
Adding sinope-gt125 to manage devices directly via the GT125 gateway
Devices are thermostat, light switch and dimmer et power switch