### PR TITLE
Create theming.md

### DIFF
--- a/custom_components/hacs/frontend/elements/hacs.css
+++ b/custom_components/hacs/frontend/elements/hacs.css
@@ -79,7 +79,7 @@
 }
 
 .installed {
-  color: var(--hacs-status-isntalled);
+  color: var(--hacs-status-installed);
 }
 
 .pending-restart {
@@ -224,7 +224,7 @@ tr.hacs-table-row:hover {
 
 /* color vars*/
 :root {
-  --hacs-status-isntalled: #126e15;
+  --hacs-status-installed: #126e15;
   --hacs-status-pending-restart: #a70000;
   --hacs-status-pending-update: #ffab40;
   --hacs-status-default: var(--primary-text-color);

--- a/custom_components/hacs/frontend/elements/hacs.css
+++ b/custom_components/hacs/frontend/elements/hacs.css
@@ -79,7 +79,7 @@
 }
 
 .installed {
-  color: var(--hacs-status-installed);
+  color: var(--hacs-status-isntalled);
 }
 
 .pending-restart {
@@ -224,7 +224,7 @@ tr.hacs-table-row:hover {
 
 /* color vars*/
 :root {
-  --hacs-status-installed: #126e15;
+  --hacs-status-isntalled: #126e15;
   --hacs-status-pending-restart: #a70000;
   --hacs-status-pending-update: #ffab40;
   --hacs-status-default: var(--primary-text-color);

--- a/docs/usage/theming.md
+++ b/docs/usage/theming.md
@@ -1,10 +1,16 @@
 # Theming
 
-HACS will try to match your Home Assistant theme as much as possible. There are also two variables
-specific to the HACS badge text and background colors (for new items in the store and to categorize custom repositories on the settings):
+HACS will try to match your Home Assistant theme as much as possible. There are also several variables you can use in your `themes.yaml` file to theme HACS further:
 
-They are `--hacs-badge-color` and `--hacs-badge-text-color`. You can customize them in your `themes.yaml` file by setting them to another
-theming variable or their own color. For example:
+| Variable  | Usage |
+| ------------- | ------------- |
+| `hacs-badge-color`  | Controls the background color on the "NEW" badges in the store, and the custom repository type badges in settings  |
+| `hacs-badge-text-color`  | Controls the text color on the "NEW" badges in the store, and the custom repository type badges in settings  |
+| `hacs-status-installed`  | Controls the icon color for installed, up-to-date components  |
+| `hacs-status-pending-restart`  | Controls the icon color for installed components that are awaiting a Home Assistant restart  |
+| `hacs-status-pending-update`  | Controls the icon color for installed components that have an update available  |
+
+Here's a basic example of customizing one of these variables in `themes.yaml`:
 
 `hacs-badge-text-color: "var(--text-primary-color)"`
 

--- a/docs/usage/theming.md
+++ b/docs/usage/theming.md
@@ -1,0 +1,17 @@
+# Theming
+
+HACS will try to match your Home Assistant theme as much as possible. There are also two variables
+specific to the HACS badge text and background colors (for new items in the store and to categorize custom repositories on the settings):
+
+They are `--hacs-badge-color` and `--hacs-badge-text-color`. You can customize them in your `themes.yaml` file by setting them to another
+theming variable or their own color. For example:
+
+`hacs-badge-text-color: "var(--text-primary-color)"`
+
+<!-- Disable sidebar -->
+<script>
+let sidebar = document.getElementsByClassName("col-md-3")[0];
+sidebar.parentNode.removeChild(sidebar);
+document.getElementsByClassName("col-md-9")[0].style['padding-left'] = "0";
+</script>
+<!-- Disable sidebar -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - Settings: usage/settings.md
       - Repository: usage/repository.md
       - Gallery: usage/gallery.md
+      - Theming usage/theming.md
   - FAQ: faq.md
   - Developer?: 
       - General: developer/general.md


### PR DESCRIPTION
I didn't see anything in the documentation that calls out the new theming variables that I found after upgrading, and I felt like it didn't fit in any of the other pages, so I created a new one. It may also become more useful to have a separate page if more theming options get added down the line.

Side note, thanks for adding those variables! The previous theming vars for badges gave mine identical text and background colors. It was driving me crazy but I hadn't cared enough to try and fix it yet. When I updated HACS today I was very happy to see the new HACS specific vars for the badges.