### PR TITLE
Include Denkovi IOT Relay module custom component

### DIFF
--- a/repositories/integration
+++ b/repositories/integration
@@ -55,5 +55,6 @@
   "PiotrMachowski/Home-Assistant-custom-components-iMPK",
   "PiotrMachowski/Home-Assistant-custom-components-Burze.dzis.net",
   "PiotrMachowski/Home-Assistant-custom-components-Antistorm",
-  "ljmerza/ha-email-sensor"
+  "ljmerza/ha-email-sensor",
+  "rdehuyss/homeassistant-custom_components-denkovi"
 ]


### PR DESCRIPTION
This custom_component should adhere to all the requirements of HACS to be included in the default list.