### PR TITLE
Add: HomeAssistant-qBitTorrentAlternativeSpeed

### DIFF
--- a/repositories/integration
+++ b/repositories/integration
@@ -4,6 +4,7 @@
   "isabellaalstrom/sensor.krisinformation",
   "JurajNyiri/HomeAssistant-Tavos",
   "JurajNyiri/HomeAssistant-Atrea",
+  "JurajNyiri/HomeAssistant-qBitTorrentAlternativeSpeed",
   "TimSoethout/goodwe-sems-home-assistant",
   "bramkragten/lyric",
   "bramkragten/mind",


### PR DESCRIPTION
# qBittorrent alternative speed switch for Home Assistant
Adds ability to switch alternative speed in qBittorrent through Home Assistant.

## Usage:
Add to configuration.yaml:

```
switch:
  - platform: qbittorrent_alternative_speed
    host: [Mandatory: IP address to qbittorrent]
    username: [Mandatory: Username to sign in]
    password: [Mandatory: Password to sign in]
    port: [Optional: Port on which qbittorrent is running, default: 8080]
    protocol: [Optional: Protocol on which qbittorrent is running, default: http]
    name: [Optional: Name of switch in Home Assistant, default: qbittorrent_alternative_speed]
```