### PR TITLE
Add 'dnguyen800/air-visual-card' plugin

### DIFF
--- a/repositories/plugin
+++ b/repositories/plugin
@@ -39,5 +39,6 @@
   "RodBr/miflora-card",
   "ljmerza/our-groceries-card",
   "dmulcahey/zha-network-card",
-  "jonkristian/entur-card"
+  "jonkristian/entur-card",
+  "dnguyen800/air-visual-card"
 ]


### PR DESCRIPTION
Hi,

I wanted to add my air-visual-card plugin as a default repository. I added it as a custom repository and it was functioning properly. Please let me know if there are any issues with the file/directory structure in my repository, thanks!