### PR TITLE
Add Lovelace custom BKK-Stop card

### DIFF
--- a/repositories/plugin
+++ b/repositories/plugin
@@ -42,5 +42,6 @@
   "dmulcahey/zha-network-card",
   "jonkristian/entur-card",
   "dnguyen800/air-visual-card",
-  "PiotrMachowski/lovelace-google-keep-card"
+  "PiotrMachowski/lovelace-google-keep-card",
+  "amaximus/bkk_stop"
 ]


### PR DESCRIPTION
This is a Lovelace custom card for displaying data from the BKK Stop Information custom component available under Integrations.