### PR TITLE
Add Screenly OSE integration

### DIFF
--- a/repositories/integration
+++ b/repositories/integration
@@ -68,5 +68,6 @@
   "asantaga/wiserHomeAssistantPlatform",
   "amaximus/bkk_stop",
   "jxlarrea/ha-emfitqs",
-  "PiotrMachowski/Home-Assistant-custom-components-Google-Keep"
+  "PiotrMachowski/Home-Assistant-custom-components-Google-Keep",
+  "burnnat/media_player.screenly"
 ]


### PR DESCRIPTION
Add [Screenly integration](https://github.com/burnnat/media_player.screenly) to default repo list (I am the owner).