### PR TITLE
Add `var` integration to HACS

### DIFF
--- a/repositories/integration
+++ b/repositories/integration
@@ -69,5 +69,6 @@
   "amaximus/bkk_stop",
   "jxlarrea/ha-emfitqs",
   "PiotrMachowski/Home-Assistant-custom-components-Google-Keep",
-  "burnnat/media_player.screenly"
+  "burnnat/media_player.screenly",
+  "snarky-snark/home-assistant-variables"
 ]


### PR DESCRIPTION
This is a custom component that adds 'variable' entities to Home Assistant. More details on the [GitHub page](https://github.com/snarky-snark/home-assistant-variables).

A user requested that it be added to HACS, so here we are!