### PR TITLE
Move BKK Stop Information custom Lovelace card in its own repository

### DIFF
--- a/repositories/plugin
+++ b/repositories/plugin
@@ -43,5 +43,5 @@
   "jonkristian/entur-card",
   "dnguyen800/air-visual-card",
   "PiotrMachowski/lovelace-google-keep-card",
-  "amaximus/bkk_stop"
+  "amaximus/bkk_stop_card"
 ]


### PR DESCRIPTION
Move BKK Stop Information custom Lovelace card in its own repository.

Old name is still used for HomeAssistant BKK Stop Information custom component available through HACS Integrations.