### PR TITLE
Add discord_game custom integration

### DIFF
--- a/repositories/integration
+++ b/repositories/integration
@@ -70,5 +70,6 @@
   "jxlarrea/ha-emfitqs",
   "PiotrMachowski/Home-Assistant-custom-components-Google-Keep",
   "burnnat/media_player.screenly",
-  "snarky-snark/home-assistant-variables"
+  "snarky-snark/home-assistant-variables",
+  "Boosik/discord_game"
 ]


### PR DESCRIPTION
This is a custom Discord component that creates a sensor showing if user is online and what game he is playing.
See https://github.com/Boosik/discord_game