### PR TITLE
Convert BKK Stop Card naming to standard one

### DIFF
--- a/repositories/plugin
+++ b/repositories/plugin
@@ -43,5 +43,5 @@
   "jonkristian/entur-card",
   "dnguyen800/air-visual-card",
   "PiotrMachowski/lovelace-google-keep-card",
-  "amaximus/bkk_stop_card"
+  "amaximus/bkk-stop-card"
 ]


### PR DESCRIPTION
Update BKK Stop Card naming to standard one and have the underscores and dashes consistent.

Will add former bkk_stop_card to blacklist in a different pull request.