### PR TITLE
Blacklist underscored BKK Stop Card

### DIFF
--- a/repositories/blacklist
+++ b/repositories/blacklist
@@ -27,5 +27,6 @@
   "custom-components/information",
   "ljmerza/waze-card",
   "custom-components/custom_updater",
-  "boralyl/hass-smartthinq"
+  "boralyl/hass-smartthinq",
+  "amaximus/bkk_stop_card"
 ]


### PR DESCRIPTION
BKK Stop Card was converted to follow the naming convention using dashes (and not underscored).
Old - underscored - BKK Stop Card repo will be removed.