### PR TITLE
Add custom-cards/spotify-card

### DIFF
--- a/repositories/plugin
+++ b/repositories/plugin
@@ -44,5 +44,6 @@
   "dnguyen800/air-visual-card",
   "PiotrMachowski/lovelace-google-keep-card",
   "amaximus/bkk-stop-card",
-  "postlund/search-card"
+  "postlund/search-card",
+  "custom-cards/spotify-card"
 ]


### PR DESCRIPTION
Conforms to the guidelines it has both the file in /dist as well as a GH release.