### PR TITLE
Wrap progress bar and add margin

### DIFF
--- a/custom_components/hacs/frontend/elements/hacs.css
+++ b/custom_components/hacs/frontend/elements/hacs.css
@@ -58,6 +58,12 @@
   height: 100%;
 }
 
+.progressbar {
+  margin-left: 2.5%;
+  margin-right: 2.5%;
+  margin-bottom: 20px;
+}
+
 .hacs-card-title {
   font-size: medium;
   color: var(--primary-text-color);

--- a/custom_components/hacs/frontend/templates/base.html
+++ b/custom_components/hacs/frontend/templates/base.html
@@ -23,11 +23,11 @@
     </nav>
   </div>
   <div id="main" class="hacs-content">
-    <div style="display: {{ progressbar }}">
+    <div class="progressbar" style="display: {{ progressbar }}">
       <p>Background task running, this page will reload when it's done.</p>
-    </div>
-    <div class="progress hacs-bar-background" id="progressbar" style="display: {{ progressbar }}">
-      <div class="indeterminate hacs-bar"></div>
+      <div class="progress hacs-bar-background" id="progressbar">
+        <div class="indeterminate hacs-bar"></div>
+      </div>
     </div>
     <div class="loading hidden">
       <div class='uil-ring-css' style='transform:scale(0.79);'>


### PR DESCRIPTION
I wrapped the progress bar and added margin to it, so it's aligned with all the other content.

BTW: Is there a way to get the name of the current template? 
Something like: 
`hacs.currentTemplate` 

My goal is to highlight the tab of the current template. So I can add something like this:
```
{% set overviewActive = 'active' if hacs.currentTemplate is 'overview' else 'none' %}
```