### PR TITLE
Updated compatible Home Assistant version

### DIFF
--- a/docs/installation/manual.md
+++ b/docs/installation/manual.md
@@ -6,7 +6,7 @@ The easiest way to make sure that you have them all is to download the `.zip` fi
 
 ## Prerequisittes
 
-- **You need to use Home Assistant version 0.92.0 or newer for this to work.**
+- **You need to use Home Assistant version 0.97.0 or newer for the latest version of HACS to work. Check the release notes before you download as this page may be slightly out of date.**
 - **If you move from [`custom_updater`](https://github.com/custom-components/custom_updater) to this see the special note at the bottom here.**
 
 ## Installation steps


### PR DESCRIPTION
The latest version requires 0.97. This confused me as I didn't realise that as this documentation page seems to indicate that 0.92 should work.