### PR TITLE
Add FRITZ!Box Tools integration

### DIFF
--- a/repositories/integration
+++ b/repositories/integration
@@ -101,5 +101,6 @@
   "tmechen/ber_status",
   "lukas-hetzenecker/home-assistant-remote",
   "Michsior14/ha-kaiterra",
-  "heinoldenhuis/home_assistant_area_waste"
+  "heinoldenhuis/home_assistant_area_waste",
+  "mammuth/ha-fritzbox-tools"
 ]


### PR DESCRIPTION
A custom component which allows you to control your FRITZ!Box router.