### PR TITLE
Catch Json error in manifest

### DIFF
--- a/custom_components/hacs/repositories/repository.py
+++ b/custom_components/hacs/repositories/repository.py
@@ -2,6 +2,7 @@
 # pylint: disable=broad-except, bad-continuation, no-member
 import pathlib
 import json
+from json.decoder import JSONDecodeError
 from distutils.version import LooseVersion
 from integrationhelper import Validate, Logger
 from aiogithubapi import AIOGitHubException
@@ -459,7 +460,7 @@ class HacsRepository(Hacs):
         try:
             manifest = await self.repository_object.get_contents("hacs.json", self.ref)
             self.repository_manifest = HacsManifest(json.loads(manifest.content))
-        except AIOGitHubException:  # Gotta Catch 'Em All
+        except (AIOGitHubException, JSONDecodeError):  # Gotta Catch 'Em All
             pass
 
     async def get_info_md_content(self):


### PR DESCRIPTION
Hi! 

I had some errors when a manifest file could be downloaded but wasn't valid json, which caused the update process to cancel halfway:

```
2019-09-17 22:05:00 INFO (MainThread) [hacs.repository.integration.eifinger.open_route_service] Registration complete
2019-09-17 22:05:01 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/home/homeassistant/.homeassistant/custom_components/hacs/hacsbase/__init__.py", line 154, in startup_tasks
    await self.load_known_repositories()
  File "/home/homeassistant/.homeassistant/custom_components/hacs/hacsbase/__init__.py", line 283, in load_known_repositories
    await self.register_repository(repo, category)
  File "/home/homeassistant/.homeassistant/custom_components/hacs/hacsbase/__init__.py", line 131, in register_repository
    await repository.registration()
  File "/home/homeassistant/.homeassistant/custom_components/hacs/repositories/integration.py", line 80, in registration
    if not await self.validate_repository():
  File "/home/homeassistant/.homeassistant/custom_components/hacs/repositories/integration.py", line 39, in validate_repository
    await self.common_validate()
  File "/home/homeassistant/.homeassistant/custom_components/hacs/repositories/repository.py", line 289, in common_validate
    await self.get_repository_manifest_content()
  File "/home/homeassistant/.homeassistant/custom_components/hacs/repositories/repository.py", line 461, in get_repository_manifest_content
    self.repository_manifest = HacsManifest(json.loads(manifest.content))
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 355, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 3 column 1 (char 23)
```
