### PR TITLE
Remove device_info property

### DIFF
--- a/custom_components/hacs/sensor.py
+++ b/custom_components/hacs/sensor.py
@@ -3,7 +3,6 @@
 from integrationhelper import Logger
 from homeassistant.helpers.entity import Entity
 from .hacsbase import Hacs as hacs
-from .const import DOMAIN, VERSION, NAME_LONG, PROJECT_URL
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -79,12 +78,3 @@ class HACSSensor(Entity):
                 }
             )
         return {"repositories": data}
-
-    @property
-    def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self.unique_id)},
-            "name": NAME_LONG,
-            "sw_version": VERSION,
-            "manufacturer": PROJECT_URL,
-        }


### PR DESCRIPTION
Removing device_info will cause the HACS sensor will not to be treated as an entity of the physical device.
Discussion about that: https://community.home-assistant.io/t/custom-component-hacs/121727/449