### PR TITLE
Add midnight theme to HACS

### DIFF
--- a/repositories/theme
+++ b/repositories/theme
@@ -1,4 +1,5 @@
 [
+  "pho3nixf1re/home-assistant-theme-midnight",
   "seangreen2/slate_theme",
   "bbbenji/synthwave-hass"
 ]


### PR DESCRIPTION
I have created a repo for managing the midnight theme. Background can be found in [this thread](https://community.home-assistant.io/t/midnight-theme/28598) from the community forums.

Closes https://github.com/pho3nixf1re/home-assistant-theme-midnight/issues/1 .