### PR TITLE
SamsungTV Custom Component

### DIFF
--- a/repositories/integration
+++ b/repositories/integration
@@ -115,5 +115,6 @@
   "gieljnssns/kostalpiko-sensor-homeassistant",
   "gieljnssns/buienalarm-sensor-homeassistant",
   "danobot/entity-controller",
-  "scottyphillips/mitsubishi_hass" 
+  "scottyphillips/mitsubishi_hass",
+  "roberodin/ha-samsungtv-custom"
 ]


### PR DESCRIPTION
This is a modified version of the built-in samsungtv with some extra features:
-Ability to send keys using a native Home Assistant service for several purposes as create a remote control in Lovelace, etc..
-Ability to customize source list at media player dropdown list