### PR TITLE
Explain why HACS needs a Github Token

### DIFF
--- a/documentation/content/configuration/pat.md
+++ b/documentation/content/configuration/pat.md
@@ -3,9 +3,9 @@ id: pat
 title: Github Personal Access Token
 ---
 
-In order to work properly, HACS needs to retrieve lots information about custom elements using Github's API.
+In order to work, HACS needs to retrieve information about repositories using Github's API.
 
-Because of the [limits fixed by Github](https://developer.github.com/v3/#rate-limiting), HACS needs to be authenticated by a Personal Access Token, that you can generate using the following steps.
+Because of the [rate limits set by Github](https://developer.github.com/v3/#rate-limiting), HACS needs to be authenticated by a Personal Access Token, that you can generate using the following steps.
 
 This token will have read-only access to public information, and will only be used by HACS to call Github's API.
 

--- a/documentation/content/configuration/pat.md
+++ b/documentation/content/configuration/pat.md
@@ -3,7 +3,11 @@ id: pat
 title: Github Personal Access Token
 ---
 
-The token generated below will only have read-only access to public information.
+In order to work properly, HACS needs to retrieve lots information about custom elements using Github's API.
+
+Because of the [limits fixed by Github](https://developer.github.com/v3/#rate-limiting), HACS needs to be authenticated by a Personal Access Token, that you can generate using the following steps.
+
+This token will have read-only access to public information, and will only be used by HACS to call Github's API.
 
 ## Step 1 - Open browser
 


### PR DESCRIPTION
Add a few lines in documentation to fix #710 