### PR TITLE
Fix dead link in integration front-end

### DIFF
--- a/custom_components/hacs/strings.json
+++ b/custom_components/hacs/strings.json
@@ -33,7 +33,7 @@
                     "theme": "Enable Themes discovery & tracking",
                     "token": "GitHub Personal Access Token"
                 },
-                "description": "If you need help with the configuration have a look here: https:\/\/hacs.netlify.com\/docs\/configuration\/start",
+                "description": "If you need help with the configuration have a look here: https:\/\/hacs.xyz\/docs\/configuration\/start",
                 "title": "HACS (Home Assistant Community Store)"
             }
         },

--- a/custom_components/hacs/strings.json
+++ b/custom_components/hacs/strings.json
@@ -33,7 +33,7 @@
                     "theme": "Enable Themes discovery & tracking",
                     "token": "GitHub Personal Access Token"
                 },
-                "description": "If you need help with the configuration have a look here: https:\/\/hacs.netlify.com\/installation\/configuration\/",
+                "description": "If you need help with the configuration have a look here: https:\/\/hacs.netlify.com\/docs\/configuration\/start",
                 "title": "HACS (Home Assistant Community Store)"
             }
         },


### PR DESCRIPTION
There is a link in the integration window that links to https://hacs.netlify.com/installation/configuration/ , which is a dead link.

I'm linking to https://hacs.netlify.com/docs/configuration/start instead

![image](https://user-images.githubusercontent.com/17952318/67272768-7591da80-f4bd-11e9-9888-b2c6decb4f03.png)
